### PR TITLE
Added limited support for MongoDB $elemMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ the full query using sqlFromMongo only for the WHERE clause.
   * $nin
   * $size test array length
   * $exists `{field: {$exists: <boolean>}}`. If boolean is false, then NOT $exists
+  * $elemMatch Note that MongoDB syntax support is limited to exact object matching, and
+    does not include dot-notation key paths, because DocumentDB only supports exact matching,
+    e.g. `{a: {$elemMatch: {b: "hello"}}}` will work but`{a: {$elemMatch: {b: {$gt: 3}}}}` will
+    not, and neither will `{a: {$elemMatch: {"b.c": "hello"}}}`
 
 ### Geo:
 
@@ -129,8 +133,6 @@ the full query using sqlFromMongo only for the WHERE clause.
   * $all Easy with UDF so maybe later
   * $regex Easy with UDF so maybe later. In the mean time, maybe $startsWith, $endsWith, or 
     $contains will serve.
-  * $elemMatch Never used this in MongoDB so not on my must have list. Implementation similar
-    to $all but think $any
   * $mod Could probably do this without UDF but never used it so not high on my list although
     it could be useful for sampling
     

--- a/test/sqlFromMongoTest.coffee
+++ b/test/sqlFromMongoTest.coffee
@@ -321,6 +321,24 @@ exports.sqlFromMongoTest =
 
     test.done()
 
+  testElemMatch: (test) ->
+    mongoObject = {"a": { $elemMatch: {"b": "hello"}}}
+    expectedSQLString = 'ARRAY_CONTAINS(a, {"b":"hello"}, true)'
+    test.equal(sqlFromMongo(mongoObject), expectedSQLString)
+    expectedSQLString = 'ARRAY_CONTAINS(c.a, {"b":"hello"}, true)'
+    test.equal(sqlFromMongo(mongoObject, "c"), expectedSQLString)
+
+    mongoObject = {"a": { $elemMatch: {"b": {"x": "y"}}}}
+    expectedSQLString = 'ARRAY_CONTAINS(a, {"b":{"x":"y"}}, true)'
+    test.equal(sqlFromMongo(mongoObject), expectedSQLString)
+
+    mongoObject = {"a": { $elemMatch: {"b": {$gt: 1}}}}
+    test.throws(() -> sqlFromMongo(mongoObject))
+    mongoObject = {"a": { $elemMatch: {"b": {"c": {$gt: 1}}}}}
+    test.throws(() -> sqlFromMongo(mongoObject))
+    
+    test.done()
+
   testSQLAlready: (test) ->
     sqlString = 'SELECT * FROM c WHERE c.a = 1'
     test.equal(sqlFromMongo(sqlString), sqlString)


### PR DESCRIPTION
I finally ran into a use case for supporting the [MongoDB `$elemMatch` syntax](https://docs.mongodb.com/manual/reference/operator/query/elemMatch/), so I'd like to add it.

After reading through the [~DocumentDB~ CosmosDB docs](https://docs.microsoft.com/en-us/azure/cosmos-db/documentdb-sql-query-reference#bk_array_contains) I realized that we can't support _everything_ that MongoDB supports, because the `$elemMatch` query essentially allows for any sort of query, while CosmosDB appears to only support exact object matching. That is sufficient for our use case though, so I think it's definitely worth adding.